### PR TITLE
Replace RenderJson with RenderJSON (not supported)

### DIFF
--- a/generate_controller.go
+++ b/generate_controller.go
@@ -176,10 +176,10 @@ func (c {{contorllerStructName}}) Index() revel.Result {
 	if err != nil{
 		errResp := buildErrResponse(err,"500")
 		c.Response.Status = 500
-		return c.RenderJson(errResp)
+		return c.RenderJSON(errResp)
 	}
 	c.Response.Status = 200
-    return c.RenderJson({{modelObjects}})
+    return c.RenderJSON({{modelObjects}})
 }
 
 func (c {{contorllerStructName}}) Show(id string) revel.Result {  
@@ -192,25 +192,25 @@ func (c {{contorllerStructName}}) Show(id string) revel.Result {
     if id == ""{
     	errResp := buildErrResponse(errors.New("Invalid {{modelObject}} id format"),"400")
     	c.Response.Status = 400
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
 
     {{modelObject}}ID, err = convertToObjectIdHex(id)
     if err != nil{
     	errResp := buildErrResponse(errors.New("Invalid {{modelObject}} id format"),"400")
     	c.Response.Status = 400
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
 
     {{modelObject}}, err = models.Get{{modelStruct}}({{modelObject}}ID)
     if err != nil{
     	errResp := buildErrResponse(err,"500")
     	c.Response.Status = 500
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
   
     c.Response.Status = 200
-    return c.RenderJson({{modelObject}})
+    return c.RenderJSON({{modelObject}})
 }
 
 func (c {{contorllerStructName}}) Create() revel.Result {  
@@ -223,17 +223,17 @@ func (c {{contorllerStructName}}) Create() revel.Result {
 	if err != nil {
 		errResp := buildErrResponse(err, "403")
 		c.Response.Status = 403
-		return c.RenderJson(errResp)
+		return c.RenderJSON(errResp)
 	}
 
 	{{modelObject}}, err = models.Add{{modelStruct}}({{modelObject}})
 	if err != nil{
 		errResp := buildErrResponse(err,"500")
     	c.Response.Status = 500
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
 	}
     c.Response.Status = 201
-    return c.RenderJson({{modelObject}})
+    return c.RenderJSON({{modelObject}})
 }
 
 func (c {{contorllerStructName}}) Update() revel.Result {  
@@ -245,16 +245,16 @@ func (c {{contorllerStructName}}) Update() revel.Result {
 	if err != nil{
 		errResp := buildErrResponse(err,"400")
     	c.Response.Status = 400
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
 	}
 
 	err = {{modelObject}}.Update{{modelStruct}}()
 	if err != nil{
 		errResp := buildErrResponse(err,"500")
     	c.Response.Status = 500
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
 	}
-    return c.RenderJson({{modelObject}})
+    return c.RenderJSON({{modelObject}})
 }
 
 func (c {{contorllerStructName}}) Delete(id string) revel.Result { 
@@ -266,30 +266,30 @@ func (c {{contorllerStructName}}) Delete(id string) revel.Result {
      if id == ""{
     	errResp := buildErrResponse(errors.New("Invalid {{modelObject}} id format"),"400")
     	c.Response.Status = 400
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
 
     {{modelObject}}ID, err = convertToObjectIdHex(id)
     if err != nil{
     	errResp := buildErrResponse(errors.New("Invalid {{modelObject}} id format"),"400")
     	c.Response.Status = 400
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
 
     {{modelObject}}, err = models.Get{{modelStruct}}({{modelObject}}ID)
     if err != nil{
     	errResp := buildErrResponse(err,"500")
     	c.Response.Status = 500
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
     }
 	err = {{modelObject}}.Delete{{modelStruct}}()
 	if err != nil{
 		errResp := buildErrResponse(err,"500")
     	c.Response.Status = 500
-    	return c.RenderJson(errResp)
+    	return c.RenderJSON(errResp)
 	} 
 	c.Response.Status = 204
-    return c.RenderJson(nil)
+    return c.RenderJSON(nil)
 }
 `
 


### PR DESCRIPTION
NOTE: From v0.14, the following changes:
`RenderJson` is now `RenderJSON`
`RenderJsonP` is now `RenderJSONP`
`RenderXml` is now `RenderXML`